### PR TITLE
Add more SystemLink Service models

### DIFF
--- a/bin/build.sh
+++ b/bin/build.sh
@@ -9,6 +9,11 @@ git clone https://github.com/ni/systemlink-OpenAPI-documents.git 2> /dev/null ||
 echo "Copying model definitions"
 cp systemlink-OpenAPI-documents/tag/nitag.yml build/models/tags.yml
 cp systemlink-OpenAPI-documents/message/nimessage.yml build/models/messages.yml
+cp systemlink-OpenAPI-documents/alarm/nialarm.yml build/models/alarms.yml
+cp systemlink-OpenAPI-documents/tag-historian/nitaghistorian.yml build/models/taghistory.yml
+cp systemlink-OpenAPI-documents/tag-rule/nitagrule.yml build/models/tagrules.yml
+cp systemlink-OpenAPI-documents/test-monitor/nitestmonitor-v2.yml build/models/tests.yml
+cp systemlink-OpenAPI-documents/tdm-reader/nitdmreader.yml build/models/tdms.yml
 
 # download dependencies
 echo "Downloading golang dependencies"

--- a/internal/parser/swaggerparser.go
+++ b/internal/parser/swaggerparser.go
@@ -63,7 +63,10 @@ func (p SwaggerParser) parseType(typeInfo string, items *spec.SchemaOrArray) mod
 	case "object":
 		return model.ObjectType
 	case "array":
-		arrayType := items.Schema.Type[0]
+		arrayType := "object"
+		if len(items.Schema.Type) > 0 {
+			arrayType = items.Schema.Type[0]
+		}
 		return p.parseArrayType(arrayType)
 	}
 	panic("Unknown type found in swagger model: " + typeInfo)
@@ -103,7 +106,11 @@ func (p SwaggerParser) parseProperties(schema *spec.Schema, location model.Param
 	var result []model.Parameter
 
 	for name, property := range schema.Properties {
-		var typeInfo = p.parseType(property.Type[0], property.Items)
+		propertyType := "object"
+		if len(property.Type) > 0 {
+			propertyType = property.Type[0]
+		}
+		var typeInfo = p.parseType(propertyType, property.Items)
 		var description = property.Description
 		var required = p.contains(name, schema.Required)
 

--- a/test/integrationtest/basic_test.go
+++ b/test/integrationtest/basic_test.go
@@ -14,11 +14,26 @@ func TestAllServicesRegistered(t *testing.T) {
 	}
 
 	output := string(stdout)
+	if !strings.Contains(output, "alarms") {
+		t.Errorf("Alarm Service was not registered: %s", output)
+	}
 	if !strings.Contains(output, "messages") {
-		t.Errorf("Message service was not registered: %s", output)
+		t.Errorf("Message Service was not registered: %s", output)
+	}
+	if !strings.Contains(output, "taghistory") {
+		t.Errorf("Tag Historian Service was not registered: %s", output)
+	}
+	if !strings.Contains(output, "tagrules") {
+		t.Errorf("Tag Rule Engine Service was not registered: %s", output)
 	}
 	if !strings.Contains(output, "tags") {
-		t.Errorf("Tag service was not registered: %s", output)
+		t.Errorf("Tag Service was not registered: %s", output)
+	}
+	if !strings.Contains(output, "tdms") {
+		t.Errorf("TDM Reader Service was not registered: %s", output)
+	}
+	if !strings.Contains(output, "tests") {
+		t.Errorf("Test Monitor Service was not registered: %s", output)
 	}
 }
 


### PR DESCRIPTION
Added alarms, taghistory, tagrules, tmds and tests models to the CLI.
Type definition should default to "object" when type is omitted.

- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/systemlink-cli/blob/master/CONTRIBUTING.md).