### PR TITLE
Move ssh-related code into separate package

### DIFF
--- a/bin/coverage.sh
+++ b/bin/coverage.sh
@@ -1,6 +1,7 @@
 #! /bin/bash
 set -e
 
-go test -v -coverpkg=./internal/... -covermode=count -coverprofile=coverage.out ./test/...
+packages=$(go list ./internal/... | grep -v "internal/ssh" | tr '\n' ',')
+go test -v -coverpkg=$packages -covermode=count -coverprofile=coverage.out ./test/...
 
 go tool cover -html=coverage.out -o coverage.html

--- a/internal/niservice/niservice.go
+++ b/internal/niservice/niservice.go
@@ -16,6 +16,7 @@ import (
 	uuid "github.com/nu7hatch/gouuid"
 
 	"github.com/ni/systemlink-cli/internal/model"
+	"github.com/ni/systemlink-cli/internal/ssh"
 )
 
 // NIService struct is taking the parsed model, all input parameters and settings
@@ -107,8 +108,8 @@ func (s NIService) convertBytesToJSONString(value []byte) string {
 	return prettyJSON.String()
 }
 
-func (s NIService) startProxy(sshConfig SSHConfig) string {
-	proxy := &HTTPOverSSHProxy{}
+func (s NIService) startProxy(sshConfig ssh.Config) string {
+	proxy := &ssh.HTTPOverSSHProxy{}
 	localProxyURL, err := proxy.Start(sshConfig)
 	if err != nil {
 		panic(err)
@@ -116,7 +117,7 @@ func (s NIService) startProxy(sshConfig SSHConfig) string {
 	return localProxyURL
 }
 
-func (s NIService) newHTTPCLient(insecure bool, sshConfig *SSHConfig) *http.Client {
+func (s NIService) newHTTPCLient(insecure bool, sshConfig *ssh.Config) *http.Client {
 	transport := &http.Transport{
 		TLSHandshakeTimeout: 10 * time.Second,
 		TLSClientConfig:     &tls.Config{InsecureSkipVerify: insecure},
@@ -148,7 +149,7 @@ func (s NIService) send(client *http.Client, req *http.Request) *http.Response {
 	return result.(*http.Response)
 }
 
-func (s NIService) createSSHConfig(settings model.Settings) *SSHConfig {
+func (s NIService) createSSHConfig(settings model.Settings) *ssh.Config {
 	if settings.SSHProxy == "" {
 		return nil
 	}
@@ -162,7 +163,7 @@ func (s NIService) createSSHConfig(settings model.Settings) *SSHConfig {
 		username = url.User.Username()
 	}
 
-	return &SSHConfig{
+	return &ssh.Config{
 		HostName:  url.Host,
 		KeyFile:   settings.SSHKey,
 		KnownHost: settings.SSHKnownHost,

--- a/internal/ssh/http_over_ssh_proxy.go
+++ b/internal/ssh/http_over_ssh_proxy.go
@@ -1,4 +1,4 @@
-package niservice
+package ssh
 
 import (
 	"fmt"
@@ -10,8 +10,8 @@ import (
 	"golang.org/x/crypto/ssh"
 )
 
-// SSHConfig contains all the parameters needed to open an SSH connection
-type SSHConfig struct {
+// Config contains all the parameters needed to open an SSH connection
+type Config struct {
 	HostName  string
 	KeyFile   string
 	KnownHost string
@@ -24,7 +24,7 @@ type HTTPOverSSHProxy struct{}
 
 // Start connects through SSH to the given hostname and spins up the HTTP proxy
 // which forwards all requests
-func (proxy *HTTPOverSSHProxy) Start(sshConfig SSHConfig) (string, error) {
+func (proxy *HTTPOverSSHProxy) Start(sshConfig Config) (string, error) {
 	client, err := proxy.connectToProxy(sshConfig)
 	if err != nil {
 		return "", err
@@ -44,7 +44,7 @@ func (proxy *HTTPOverSSHProxy) Start(sshConfig SSHConfig) (string, error) {
 	return fmt.Sprintf("localhost:%v", port), nil
 }
 
-func (proxy *HTTPOverSSHProxy) connectToProxy(sshConfig SSHConfig) (*ssh.Client, error) {
+func (proxy *HTTPOverSSHProxy) connectToProxy(sshConfig Config) (*ssh.Client, error) {
 	config := proxy.clientConfig(sshConfig)
 	client, err := ssh.Dial("tcp", sshConfig.HostName, config)
 	if err != nil {
@@ -54,7 +54,7 @@ func (proxy *HTTPOverSSHProxy) connectToProxy(sshConfig SSHConfig) (*ssh.Client,
 	return client, nil
 }
 
-func (proxy *HTTPOverSSHProxy) clientConfig(sshConfig SSHConfig) *ssh.ClientConfig {
+func (proxy *HTTPOverSSHProxy) clientConfig(sshConfig Config) *ssh.ClientConfig {
 	return &ssh.ClientConfig{
 		User: sshConfig.UserName,
 		Auth: []ssh.AuthMethod{


### PR DESCRIPTION
Moved the HTTPOverSSHProxy struct into a separate package

- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/systemlink-cli/blob/master/CONTRIBUTING.md).