### PR TITLE
Handle parser errors and print proper stderr messages

### DIFF
--- a/bin/build.sh
+++ b/bin/build.sh
@@ -1,7 +1,7 @@
 #! /bin/bash
 set -e
 
-# download tag and message service swagger.json
+# download service swagger yaml files
 echo "Cloning systemlink-OpenAPI-documents repo"
 mkdir -p build/models
 git clone https://github.com/ni/systemlink-OpenAPI-documents.git 2> /dev/null || (cd systemlink-OpenAPI-documents ; git pull)

--- a/internal/commandline/cli.go
+++ b/internal/commandline/cli.go
@@ -278,8 +278,12 @@ func (c CLI) buildCommands(definitions []model.Definition) []*cli.Command {
 
 // Exec : Parses the given API models, validates and executes
 // the given command line arguments
-func (c CLI) Exec(args []string, models []model.Data) *cli.App {
-	definitions := c.Parser.Parse(models)
+func (c CLI) Exec(args []string, models []model.Data) (*cli.App, int) {
+	definitions, err := c.Parser.Parse(models)
+	if err != nil {
+		fmt.Fprintln(c.ErrWriter, err)
+		return nil, 1
+	}
 	commands := c.buildCommands(definitions)
 
 	app := &cli.App{
@@ -294,5 +298,5 @@ func (c CLI) Exec(args []string, models []model.Data) *cli.App {
 	}
 
 	app.Run(args)
-	return app
+	return app, 0
 }

--- a/internal/commandline/config.go
+++ b/internal/commandline/config.go
@@ -1,6 +1,7 @@
 package commandline
 
 import (
+	"fmt"
 	"path/filepath"
 	"strings"
 
@@ -46,14 +47,14 @@ func (c *Config) resolvePaths(baseDir string) {
 
 // NewConfig initializes a new Config structure based on the yaml data
 // in the given byte stream
-func NewConfig(input []byte, baseDir string) Config {
+func NewConfig(input []byte, baseDir string) (Config, error) {
 	c := Config{}
 	err := yaml.Unmarshal(input, &c)
 	c.resolvePaths(baseDir)
 	if err != nil {
-		panic("Error loading configuration file: " + err.Error())
+		err = fmt.Errorf("Error reading yaml: %v", err)
 	}
-	return c
+	return c, err
 }
 
 func (c *Config) findProfile(profileName string) profile {

--- a/internal/commandline/parser.go
+++ b/internal/commandline/parser.go
@@ -5,5 +5,5 @@ import "github.com/ni/systemlink-cli/internal/model"
 // Parser interface which turns the given byte stream into
 // a structured service definition model with all declared operations.
 type Parser interface {
-	Parse(models []model.Data) []model.Definition
+	Parse(models []model.Data) ([]model.Definition, error)
 }

--- a/internal/parser/parse_error.go
+++ b/internal/parser/parse_error.go
@@ -1,0 +1,23 @@
+package parser
+
+import "fmt"
+
+// ParseError returned when the input is an invalid model
+type ParseError struct {
+	Message string
+	Err     error
+}
+
+func (e *ParseError) Error() string {
+	return e.Message + ": " + e.Err.Error()
+}
+
+// NewParseError initializes a new error which happened during
+// parsing and keeps the context of the model which is being
+// processed
+func NewParseError(name string, err error) *ParseError {
+	return &ParseError{
+		Message: fmt.Sprintf("Error parsing model '%s'", name),
+		Err:     err,
+	}
+}

--- a/internal/ssh/http_over_ssh_proxy.go
+++ b/internal/ssh/http_over_ssh_proxy.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"net"
 	"net/http"
+	"net/url"
 
 	"github.com/elazarl/goproxy"
 	"golang.org/x/crypto/ssh"
@@ -16,6 +17,29 @@ type Config struct {
 	KeyFile   string
 	KnownHost string
 	UserName  string
+}
+
+// NewConfig initializes a new ssh config structure
+func NewConfig(proxyURL string, key string, knownHost string) *Config {
+	if proxyURL == "" {
+		return nil
+	}
+
+	url, err := url.Parse("//" + proxyURL)
+	if err != nil {
+		panic(err)
+	}
+	username := "ubuntu"
+	if url.User != nil {
+		username = url.User.Username()
+	}
+
+	return &Config{
+		HostName:  url.Host,
+		KeyFile:   key,
+		KnownHost: knownHost,
+		UserName:  username,
+	}
 }
 
 // HTTPOverSSHProxy tunnels HTTP requests through SSH by opening a proxy

--- a/test/unittest/cli_call_test.go
+++ b/test/unittest/cli_call_test.go
@@ -2,6 +2,7 @@ package unit_test
 
 import (
 	"bytes"
+	"fmt"
 	"path/filepath"
 	"reflect"
 	"testing"
@@ -24,16 +25,20 @@ func (s *fakeService) Call(operation model.Operation, parameterValues []model.Pa
 	return 200, "", nil
 }
 
-func createCliWithFakeService(config string) (commandline.CLI, *bytes.Buffer, *bytes.Buffer, *fakeService) {
+func createCliWithFakeService(configData string) (commandline.CLI, *bytes.Buffer, *bytes.Buffer, *fakeService) {
 	writer := new(bytes.Buffer)
 	errWriter := new(bytes.Buffer)
 	service := fakeService{}
+	config, err := commandline.NewConfig([]byte(configData), "/home")
+	if err != nil {
+		fmt.Fprintln(errWriter, "Error reading config:", err)
+	}
 	c := commandline.CLI{
 		Parser:    parser.SwaggerParser{},
 		Service:   &service,
 		Writer:    writer,
 		ErrWriter: errWriter,
-		Config:    commandline.NewConfig([]byte(config), "/home"),
+		Config:    config,
 	}
 	return c, writer, errWriter, &service
 }

--- a/test/unittest/cli_error_test.go
+++ b/test/unittest/cli_error_test.go
@@ -1,0 +1,192 @@
+package unit_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/ni/systemlink-cli/internal/model"
+)
+
+func TestInvalidModel(t *testing.T) {
+	models := []model.Data{
+		{
+			Name: "messages",
+			Content: []byte(
+				`=== INVALID ===`),
+		},
+	}
+
+	_, errWriter := callCli([]string{"messages"}, models)
+
+	errorOutput := "Error parsing model 'messages'"
+	if !strings.Contains(errWriter.String(), errorOutput) {
+		t.Errorf("Error output was wrong, got: %s, but expected to contain: %s.", errWriter.String(), errorOutput)
+	}
+}
+
+func TestInvalidModelExpansion(t *testing.T) {
+	models := []model.Data{
+		{
+			Name: "messages",
+			Content: []byte(
+				`{
+					"paths": { 
+						"/post-message": { 
+							"post": {
+								"operationId": "post-message",
+								"parameters": [
+									{ "name": "mydata", "in": "body", "required": true, "schema": { "$ref": "#/definitions/INVALID" } }
+								]
+							}
+						}
+					}
+				}`),
+		},
+	}
+
+	_, errWriter := callCli([]string{"messages"}, models)
+
+	errorOutput := "Error parsing model 'messages'"
+	if !strings.Contains(errWriter.String(), errorOutput) {
+		t.Errorf("Error output was wrong, got: %s, but expected to contain: %s.", errWriter.String(), errorOutput)
+	}
+}
+
+func TestInvalidConfigFile(t *testing.T) {
+	config := `INVALID YAML`
+
+	_, errWriter := callCliWithConfig([]string{"messages", "create"}, configDefaultModels, config)
+
+	errorOutput := "Error reading yaml"
+	if !strings.Contains(errWriter.String(), errorOutput) {
+		t.Errorf("Error output was wrong, got: %s, but expected to contain: %s.", errWriter.String(), errorOutput)
+	}
+}
+
+func TestInvalidParameterType(t *testing.T) {
+	models := []model.Data{
+		{
+			Name: "messages",
+			Content: []byte(
+				`{
+					"paths": {
+						"/create": {
+							"post": {
+								"operationId": "create",
+								"parameters": [
+									{ "name": "id", "type": "INVALID", "in": "body" }
+								]
+							}
+						}
+					}
+				}`),
+		},
+	}
+
+	_, errWriter := callCli([]string{"messages", "create"}, models)
+
+	errorOutput := "Invalid type 'INVALID'"
+	if !strings.Contains(errWriter.String(), errorOutput) {
+		t.Errorf("Error output was wrong, got: %s, but expected to contain: %s.", errWriter.String(), errorOutput)
+	}
+}
+
+func TestInvalidParameterArrayType(t *testing.T) {
+	models := []model.Data{
+		{
+			Name: "messages",
+			Content: []byte(
+				`{
+					"paths": {
+						"/create": {
+							"post": {
+								"operationId": "create",
+								"parameters": [
+									{
+										"name": "id",
+										"schema": {
+										  "type": "array",
+										  "items": {
+											"type": "INVALID_ARR"
+										  }
+										},
+										"in": "body"
+									}
+								]
+							}
+						}
+					}
+				}`),
+		},
+	}
+
+	_, errWriter := callCli([]string{"messages", "create"}, models)
+
+	errorOutput := "Invalid array type 'INVALID_ARR'"
+	if !strings.Contains(errWriter.String(), errorOutput) {
+		t.Errorf("Error output was wrong, got: %s, but expected to contain: %s.", errWriter.String(), errorOutput)
+	}
+}
+
+func TestInvalidParameterLocation(t *testing.T) {
+	models := []model.Data{
+		{
+			Name: "messages",
+			Content: []byte(
+				`{
+					"paths": {
+						"/create": {
+							"post": {
+								"operationId": "create",
+								"parameters": [
+									{ "name": "id", "type": "string", "in": "INVALID" }
+								]
+							}
+						}
+					}
+				}`),
+		},
+	}
+
+	_, errWriter := callCli([]string{"messages", "create"}, models)
+
+	errorOutput := "Invalid location 'INVALID'"
+	if !strings.Contains(errWriter.String(), errorOutput) {
+		t.Errorf("Error output was wrong, got: %s, but expected to contain: %s.", errWriter.String(), errorOutput)
+	}
+}
+
+func TestInvalidTypeInDefinition(t *testing.T) {
+	models := []model.Data{
+		{
+			Name: "messages",
+			Content: []byte(
+				`{
+					"paths": { 
+						"/post-message": { 
+							"post": { 
+								"operationId": "post-message",
+								"parameters": [
+									{ "name": "mydata", "in": "body", "required": true, "schema": { "$ref": "#/definitions/MyData" } }
+								]
+							}
+						}
+					},
+					"definitions": {
+						"MyData": {
+							"properties": {
+							    "message": { "type": "INVALID" }
+							}
+						}
+					}
+				}`),
+		},
+	}
+
+	_, errWriter := callCli([]string{"messages", "create"}, models)
+
+	errorOutput := "Invalid type 'INVALID'"
+	if !strings.Contains(errWriter.String(), errorOutput) {
+		t.Errorf("Error output was wrong, got: %s, but expected to contain: %s.", errWriter.String(), errorOutput)
+	}
+}

--- a/test/unittest/cli_test.go
+++ b/test/unittest/cli_test.go
@@ -37,6 +37,41 @@ func TestHelpOutputsAllModels(t *testing.T) {
 	}
 }
 
+func TestOutputsAllSubCommands(t *testing.T) {
+	models := []model.Data{
+		{Name: "messages", Content: []byte(`{}`)},
+		{Name: "tags", Content: []byte(`{
+			"paths": { 
+				"/tags": { 
+					"GET": { 
+						"operationId": "get-tags"
+					},
+					"POST": { 
+						"operationId": "create-tag"
+					}
+				},
+				"/subscriptions": {
+					"PUT": { 
+						"operationId": "create-subscription"
+					}
+				}
+			}
+		}`)},
+	}
+
+	writer, _ := callCli([]string{"tags"}, models)
+
+	if !strings.Contains(writer.String(), "get-tags") {
+		t.Errorf("Output was wrong, got: %s, but expected to contain: %s.", writer.String(), "get-tags")
+	}
+	if !strings.Contains(writer.String(), "create-tag") {
+		t.Errorf("Output was wrong, got: %s, but expected to contain: %s.", writer.String(), "create-tag")
+	}
+	if !strings.Contains(writer.String(), "create-subscription") {
+		t.Errorf("Output was wrong, got: %s, but expected to contain: %s.", writer.String(), "create-subscription")
+	}
+}
+
 var methodTests = []struct {
 	method string
 }{

--- a/test/unittest/utils_test.go
+++ b/test/unittest/utils_test.go
@@ -2,6 +2,7 @@ package unit_test
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -12,15 +13,19 @@ import (
 	"github.com/ni/systemlink-cli/internal/parser"
 )
 
-func createCli(config string) (commandline.CLI, *bytes.Buffer, *bytes.Buffer) {
+func createCli(configData string) (commandline.CLI, *bytes.Buffer, *bytes.Buffer) {
 	writer := new(bytes.Buffer)
 	errWriter := new(bytes.Buffer)
+	config, err := commandline.NewConfig([]byte(configData), "/home")
+	if err != nil {
+		fmt.Fprintln(errWriter, "Error reading config:", err)
+	}
 	c := commandline.CLI{
 		Parser:    parser.SwaggerParser{},
 		Service:   niservice.NIService{},
 		Writer:    writer,
 		ErrWriter: errWriter,
-		Config:    commandline.NewConfig([]byte(config), "/home"),
+		Config:    config,
 	}
 	return c, writer, errWriter
 }


### PR DESCRIPTION
Added ParseError to wrap proper parser error messages. Passing
errors through all layers and printing on stderr.

Added tests for various error cases.

- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/systemlink-cli/blob/master/CONTRIBUTING.md).