### PR TITLE
Add file upload support using multipart formdata

### DIFF
--- a/GettingStarted.md
+++ b/GettingStarted.md
@@ -68,6 +68,12 @@ token=$(./systemlink messages create-session | jq -r '.token')
 ./systemlink tags get-tag --path "mytag"
 ```
 
+## How to upload files?
+
+```bash
+./systemlink files upload --file /tmp/test.txt
+```
+
 ## Need help about the supported operations?
 
 List all message service operations:
@@ -104,6 +110,11 @@ Array types (string, integer, floating point and boolean arrays). Simply separat
 Complex types, using JSON:
 ```bash
 --properties '{ "my-values": ["a", "b", "c"] }'
+```
+
+Multi-part form data file uploads:
+```bash
+--file /tmp/myfile.txt
 ```
 
 ## How to set up a profile in the configuration file?

--- a/bin/build.sh
+++ b/bin/build.sh
@@ -14,6 +14,8 @@ cp systemlink-OpenAPI-documents/tag-historian/nitaghistorian.yml build/models/ta
 cp systemlink-OpenAPI-documents/tag-rule/nitagrule.yml build/models/tagrules.yml
 cp systemlink-OpenAPI-documents/test-monitor/nitestmonitor-v2.yml build/models/tests.yml
 cp systemlink-OpenAPI-documents/tdm-reader/nitdmreader.yml build/models/tdms.yml
+cp systemlink-OpenAPI-documents/file/nifile.yml build/models/files.yml
+cp systemlink-OpenAPI-documents/opcclient/niopcclient.yml build/models/opc.yml
 
 # download dependencies
 echo "Downloading golang dependencies"

--- a/internal/model/parameter_location.go
+++ b/internal/model/parameter_location.go
@@ -16,4 +16,7 @@ const (
 	// HeaderLocation means the parameter is stored in the http header
 	// e.g. x-ni-api-key: <api-key>
 	HeaderLocation
+	// FormDataLocation means the parameter is transferred as part
+	// of a form upload
+	FormDataLocation
 )

--- a/internal/model/parameter_type.go
+++ b/internal/model/parameter_type.go
@@ -14,6 +14,8 @@ const (
 	BooleanType
 	// ObjectType means the parameter is a generic object which is simply serialized
 	ObjectType
+	// FileType means the parameter is a file blob
+	FileType
 	// StringArrayType means the parameter is an string array
 	StringArrayType
 	// IntegerArrayType means the parameter is an integer array

--- a/internal/parser/swaggerparser.go
+++ b/internal/parser/swaggerparser.go
@@ -63,6 +63,8 @@ func (p SwaggerParser) parseType(typeInfo string, items *spec.SchemaOrArray) (mo
 		return model.BooleanType, nil
 	case "object":
 		return model.ObjectType, nil
+	case "file":
+		return model.FileType, nil
 	case "array":
 		arrayType := "object"
 		if items != nil && items.Schema != nil && len(items.Schema.Type) > 0 {
@@ -83,6 +85,8 @@ func (p SwaggerParser) parseLocation(in string) (model.ParameterLocation, error)
 		return model.QueryLocation, nil
 	case "header":
 		return model.HeaderLocation, nil
+	case "formData":
+		return model.FormDataLocation, nil
 	}
 	return 0, fmt.Errorf("Invalid location '%s'", in)
 }

--- a/test/data/test.txt
+++ b/test/data/test.txt
@@ -1,0 +1,1 @@
+my upload test file

--- a/test/integrationtest/basic_test.go
+++ b/test/integrationtest/basic_test.go
@@ -35,6 +35,12 @@ func TestAllServicesRegistered(t *testing.T) {
 	if !strings.Contains(output, "tests") {
 		t.Errorf("Test Monitor Service was not registered: %s", output)
 	}
+	if !strings.Contains(output, "files") {
+		t.Errorf("File Ingestion Service was not registered: %s", output)
+	}
+	if !strings.Contains(output, "opc") {
+		t.Errorf("OPC UA Connector Service was not registered: %s", output)
+	}
 }
 
 func TestShowsServiceOperations(t *testing.T) {

--- a/test/unittest/cli_error_test.go
+++ b/test/unittest/cli_error_test.go
@@ -242,3 +242,29 @@ paths:
 		t.Errorf("Error output was wrong, got: %s, but expected to contain: %s.", errWriter.String(), errorOutput)
 	}
 }
+
+func TestFileForUploadDoesNotExist(t *testing.T) {
+	models := []model.Data{
+		{
+			Name: "files",
+			Content: []byte(`
+---
+paths:
+  "/files":
+    post:
+      operationId: upload
+      parameters:
+      - name: file
+        type: file
+        in: formData
+`),
+		},
+	}
+
+	_, errWriter := callCli([]string{"files", "upload", "--file", "INVALID-FILE"}, models)
+
+	errorOutput := "Error creating request"
+	if !strings.Contains(errWriter.String(), errorOutput) {
+		t.Errorf("Error output was wrong, got: %s, but expected to contain: %s.", errWriter.String(), errorOutput)
+	}
+}


### PR DESCRIPTION
Added support for parameter type 'file' in form data uploads.
Reading the provided file and uploading it using multipart uploads.

Added file ingestion service and OPC UA connector service swagger
documents which are working now with file upload support.

- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/systemlink-cli/blob/master/CONTRIBUTING.md).